### PR TITLE
Feat: 启用基于 Device-Mapper 映射器的内存扩展写回设备

### DIFF
--- a/port.sh
+++ b/port.sh
@@ -868,6 +868,9 @@ fi
 echo "debug.game.video.speed=true" >> build/portrom/images/product/etc/build.prop
 echo "debug.game.video.support=true" >> build/portrom/images/product/etc/build.prop
 
+# Enable Xiaomi extm dm_opt feature
+echo "persist.miui.extm.dm_opt.enable=true" >> build/portrom/images/product/etc/build.prop
+
 # Unlock Smart fps
 
 maxFps=$(xmlstarlet sel -t -v "//integer-array[@name='fpsList']/item" build/portrom/images/product/etc/device_features/${base_rom_code}.xml | sort -nr | head -n 1)


### PR DESCRIPTION
这是一项小米在 HyperOS 1.0 后期版本和 HyperOS 2.0 新增的优化
传统写回设备基于 Loop 回环设备实现, 在写入会有开销以及性能问题等
小米新增基于映射器实现的写回设备, 这避免了产生性能开销的问题,
有助于提高内存扩展的性能和内存扩展的使用效率的问题

由于小米合并 product 代码沟通不畅, 导致部分机器缺少此 prop 属性道具,
仍在使用传统 Loop 回环设备的写回设备, 因此添加此 prop 属性道具
来手动切换为 基于 Device-mapper 的内存扩展写回设备实现.

测试: 启动 HyperOS 2.0 ROM 检测 /sys/block/zram0/backing_dev,
前: /dev/block/loopXX 后: /dev/block/dm-XX (dm-swapfile)
[注意: 仅在加密 Data 设备上有效, 解密无法创建 map Image]